### PR TITLE
Fix typo in doc comment

### DIFF
--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -50,7 +50,7 @@ pub struct WebViewAttributes {
   /// closure.
   ///
   /// The closure takes the `Window` and a url string slice as parameters, and returns a tuple of a
-  /// vector of bytes which is the content and a mimetype string of the conten.
+  /// vector of bytes which is the content and a mimetype string of the content.
   pub custom_protocols: Vec<(
     String,
     Box<dyn Fn(&Window, &str) -> Result<(Vec<u8>, String)>>,
@@ -141,7 +141,7 @@ impl<'a> WebViewBuilder<'a> {
   /// closure.
   ///
   /// The closure takes the `Window` and a url string slice as parameters, and returns a tuple of a
-  /// vector of bytes which is the content and a mimetype string of the conten.
+  /// vector of bytes which is the content and a mimetype string of the content.
   #[cfg(feature = "protocol")]
   pub fn with_custom_protocol<F>(mut self, name: String, handler: F) -> Self
   where


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Don't know what to say, it's just a small typo and I found this while reading the docs. Still should be fixed I guess
